### PR TITLE
Don't rely on deprecated relative imports, use absolute imports.

### DIFF
--- a/webobtoolkit/client.py
+++ b/webobtoolkit/client.py
@@ -1,7 +1,7 @@
 """
 this is the client api it's mostly sugar
 """
-import filters
+from webobtoolkit import filters
 from webob.client import send_request_app
 from urllib import urlencode
 from webob import Request

--- a/webobtoolkit/filters.py
+++ b/webobtoolkit/filters.py
@@ -3,7 +3,7 @@ filters for taking care of various aspects of HTTP
 """
 from webob import Request
 from cookielib import CookieJar
-import log as l
+import webobtoolkit.log as l
 import logging
 
 

--- a/webobtoolkit/log.py
+++ b/webobtoolkit/log.py
@@ -1,7 +1,7 @@
 """
 shared stuff to keep logging consistent
 """
-from constants import PAD
+from webobtoolkit.constants import PAD
 
 
 def HTTP_MSG(h):

--- a/webobtoolkit/testing.py
+++ b/webobtoolkit/testing.py
@@ -8,10 +8,10 @@ on the response, you can use it like so...
 
 >>> assert_status_code._200(request, response)
 """
-from constants import STATUS_CODES
-from log import PRINT_REQ, PRINT_RES
-from client import Client, client_pipeline
-from filters import auto_redirect_filter
+from webobtoolkit.constants import STATUS_CODES
+from webobtoolkit.log import PRINT_REQ, PRINT_RES
+from webobtoolkit.client import Client, client_pipeline
+from webobtoolkit.filters import auto_redirect_filter
 
 
 def _status_code_err_msg(request, response, expected):


### PR DESCRIPTION
I noticed the code had relative imports in them, but that's not very safe as global modules might exist with the same name. I converted it to use absolute imports. You could also use 'from .foo import .." for relative imports, but I don't know whether you want to be compatible with older versions  of Python 2.x which don't support that.

I tried to run the tests and I get a failure, but I don't think it's connected to my changes.
