### PR TITLE
Making webob more resilient to webservers that return invalid Content-Encoding headers.

### DIFF
--- a/webobtoolkit/filters.py
+++ b/webobtoolkit/filters.py
@@ -89,7 +89,11 @@ def decode_filter(app):
         request = Request(environ)
         request.accept_encoding = "gzip"
         response = request.get_response(app)
-        response.decode_content()
+        # Some web servers return an invalid `content_encoding`, make webobtookit more resilient
+        try:
+            response.decode_content()
+        except ValueError:
+            pass
         return response(environ, start_response)
     return m
 


### PR DESCRIPTION
See issue #14 for more info. Let me know your thoughts on this change. I'm happy to discuss further or make any code changes or style changes you might have. 
